### PR TITLE
feat: API - CORS best practice

### DIFF
--- a/__tests__/__utils__/test-environment.ts
+++ b/__tests__/__utils__/test-environment.ts
@@ -94,7 +94,7 @@ export abstract class TestEnvironment {
 
 class LocalEnvironment extends TestEnvironment {
   public getDomain() {
-    return global.DOMAIN
+    return 'serlo.localhost'
   }
 
   public async fetchRequest(originalRequest: Request): Promise<Response> {

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -87,18 +87,20 @@ describe('setting of response header `Access-Control-Allow-Origin`', () => {
   })
 
   describe('when `Origin` is not from the current serlo domain, the current serlo domain is returned as `Access-Control-Allow-Origin`', () => {
-    test.each([`http://verybad-${env.getDomain()}`])(
-      'when `Origin` is `%s`',
-      async (origin) => {
-        const response = await fetchApi({
-          headers: origin ? { Origin: origin } : {},
-        })
+    test.each([
+      `http://verybad-${env.getDomain()}`,
+      '*',
+      'null',
+      'http//invalid-url',
+    ])('when `Origin` is `%s`', async (origin) => {
+      const response = await fetchApi({
+        headers: origin ? { Origin: origin } : {},
+      })
 
-        expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
-          currentDomain
-        )
-      }
-    )
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+        currentDomain
+      )
+    })
   })
 })
 

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -105,3 +105,7 @@ test("header `Access-Control-Allow-Origin` is set to Serlo's domain or subdomain
     responseWithWrongOrigin.headers.get('Access-Control-Allow-Origin')
   ).not.toBe(`https://verybad-${env.getDomain()}`)
 })
+
+test('header `Vary` avoids caching of Origin header', () => {
+  expect(response.headers.get('Vary')).toBe('Origin')
+})

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -73,27 +73,29 @@ async function fetchWithOriginHeader(origin: string) {
 }
 
 test("header `Access-Control-Allow-Origin` is set to Serlo's domain or subdomains", async () => {
-  const domainUrl = `https://${env.getDomain()}`
+  const domainOrigin = `https://${env.getDomain()}`
 
   const responseWithoutOriginHeader = response
 
   expect(
     responseWithoutOriginHeader.headers.get('Access-Control-Allow-Origin')
-  ).toBe(domainUrl)
+  ).toBe(domainOrigin)
 
-  const responseWithRightDomain = await fetchWithOriginHeader(domainUrl)
+  const responseWithRightDomain = await fetchWithOriginHeader(domainOrigin)
 
   expect(
     responseWithRightDomain.headers.get('Access-Control-Allow-Origin')
-  ).toBe(domainUrl)
+  ).toBe(domainOrigin)
 
-  const subdomainUrl = `https://de.${env.getDomain()}`
+  const subdomainOrigin = `https://de.${env.getDomain()}`
 
-  const responseWithRightSubdomain = await fetchWithOriginHeader(subdomainUrl)
+  const responseWithRightSubdomain = await fetchWithOriginHeader(
+    subdomainOrigin
+  )
 
   expect(
     responseWithRightSubdomain.headers.get('Access-Control-Allow-Origin')
-  ).toBe(subdomainUrl)
+  ).toBe(subdomainOrigin)
 
   const responseWithWrongOrigin = await fetchWithOriginHeader(
     `https://verybad-${env.getDomain()}`

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -41,6 +41,7 @@ import {
   currentTestEnvironment,
   givenFrontend,
   defaultFrontendServer,
+  localTestEnvironment,
 } from './__tests__/__utils__'
 
 const timeout = currentTestEnvironment().getNeededTimeout()
@@ -57,7 +58,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   global.API_SECRET = 'secret'
-  global.DOMAIN = 'serlo.localhost'
+  global.DOMAIN = localTestEnvironment().getDomain()
   global.ENVIRONMENT = 'local'
   global.FRONTEND_DOMAIN = 'frontend.serlo.localhost'
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,6 +35,7 @@ export async function api(request: Request) {
     'Access-Control-Allow-Origin',
     setAllowedOrigin(request.headers.get('Origin'))
   )
+  response.headers.set('Vary', 'Origin')
   return response
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,7 +35,11 @@ export async function api(request: Request) {
     'Access-Control-Allow-Origin',
     setAllowedOrigin(request.headers.get('Origin'))
   )
+
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#cors_and_caching
+  // for an explanation why this header is needed to be set
   response.headers.set('Vary', 'Origin')
+
   return response
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -39,14 +39,14 @@ export async function api(request: Request) {
 }
 
 function setAllowedOrigin(requestOrigin: string | null) {
-  const domainUrl = `https://${global.DOMAIN}`
+  const domainOrigin = `https://${global.DOMAIN}`
 
-  if (requestOrigin === null) return domainUrl
+  if (requestOrigin === null) return domainOrigin
 
   const requestDomain = new Url(requestOrigin).domain
   if (requestDomain === global.DOMAIN) return requestOrigin
 
-  return domainUrl
+  return domainOrigin
 }
 
 export async function fetchApi(request: Request) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,9 +31,10 @@ export async function api(request: Request) {
 
   const originalResponse = await fetchApi(request)
   const response = new Response(originalResponse.body, originalResponse)
+
   response.headers.set(
     'Access-Control-Allow-Origin',
-    setAllowedOrigin(request.headers.get('Origin'))
+    getAllowedOrigin(request.headers.get('Origin'))
   )
 
   // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#cors_and_caching
@@ -41,17 +42,6 @@ export async function api(request: Request) {
   response.headers.set('Vary', 'Origin')
 
   return response
-}
-
-function setAllowedOrigin(requestOrigin: string | null) {
-  const domainOrigin = `https://${global.DOMAIN}`
-
-  if (requestOrigin === null) return domainOrigin
-
-  const requestDomain = new Url(requestOrigin).domain
-  if (requestDomain === global.DOMAIN) return requestOrigin
-
-  return domainOrigin
 }
 
 export async function fetchApi(request: Request) {
@@ -76,4 +66,13 @@ async function getAuthorizationHeader(request: Request) {
   } else {
     return `Serlo Service=${serviceToken}`
   }
+}
+
+function getAllowedOrigin(requestOrigin: string | null) {
+  const domainOrigin = `https://${global.DOMAIN}`
+
+  return requestOrigin != null &&
+    new Url(requestOrigin).domain === global.DOMAIN
+    ? requestOrigin
+    : domainOrigin
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,15 +29,24 @@ export async function api(request: Request) {
   if (url.subdomain !== 'api') return null
   if (url.pathname !== '/graphql') return null
 
-  // Actually, the header `Access-Control-Allow-Origin` is supposed to be
-  // handled in api but Cloudflare keeps somehow setting it to `*`
   const originalResponse = await fetchApi(request)
   const response = new Response(originalResponse.body, originalResponse)
   response.headers.set(
     'Access-Control-Allow-Origin',
-    request.headers.get('Origin') ?? '*'
+    setAllowedOrigin(request.headers.get('Origin'))
   )
   return response
+}
+
+function setAllowedOrigin(requestOrigin: string | null) {
+  const domainUrl = `https://${global.DOMAIN}`
+
+  if (requestOrigin === null) return domainUrl
+
+  const requestDomain = new Url(requestOrigin).domain
+  if (requestDomain === global.DOMAIN) return requestOrigin
+
+  return domainUrl
 }
 
 export async function fetchApi(request: Request) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,10 +69,18 @@ async function getAuthorizationHeader(request: Request) {
 }
 
 function getAllowedOrigin(requestOrigin: string | null) {
-  const domainOrigin = `https://${global.DOMAIN}`
+  try {
+    if (
+      requestOrigin != null &&
+      requestOrigin !== '*' &&
+      requestOrigin !== 'null' &&
+      new Url(requestOrigin).domain === global.DOMAIN
+    ) {
+      return requestOrigin
+    }
+  } catch (err) {
+    // return default value
+  }
 
-  return requestOrigin != null &&
-    new Url(requestOrigin).domain === global.DOMAIN
-    ? requestOrigin
-    : domainOrigin
+  return `https://${global.DOMAIN}`
 }


### PR DESCRIPTION
`Access-Control-Allow-Origin` can only have three values: *, \<origin\> or null (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), that's why we have to dynamically set the origin for the subdomains.

It's quite impossible to receive a browser request from origin 'htt<span>ps://serlo.org', but I didn't want to risk it, so I also set it to positively respond for this origin.

Since localhost frontend makes request via server side function we don't have to cover its case.