### PR TITLE
Add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
In order to also keep the used GitHub Actions in the workflows up to date.

Related to https://github.com/serlo/cloudflare-worker/issues/418.