### PR TITLE
refactor: Remove unused function createEmptyBodyResponse()

### DIFF
--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -22,7 +22,6 @@ import {
   getPathInfo,
   Instance,
   toCacheKey,
-  createEmptyBodyResponse,
 } from '../src/utils'
 
 describe('getCookieValue()', () => {
@@ -228,13 +227,6 @@ test('PreactResponse', async () => {
   expect(hello.status).toBe(200)
   expectContentTypeIsHtml(hello)
   await expectContainsText(hello, ['<h1>Hello</h1>'])
-
-  const notModified = createEmptyBodyResponse({ status: 304 })
-
-  expect(notModified.status).toBe(304)
-  expectContentTypeIsHtml(notModified)
-  expect(notModified).not.toBeNull()
-  expect(await notModified.text()).toEqual('')
 })
 
 test('JsonResponse', async () => {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -170,12 +170,6 @@ export function markdownToHtml(markdown: string): string {
   return marked.parse(markdown, { headerIds: false, mangle: false }).trim()
 }
 
-// The HTTP Status code 304 Not Modified must not contain a body.
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304
-export function createEmptyBodyResponse(opt: ResponseInit) {
-  return createPreactResponse(null, opt)
-}
-
 export function createPreactResponse(
   component: VNode | null,
   opt?: ResponseInit


### PR DESCRIPTION
This function is nowhere used in the production code