### PR TITLE
Update worker format

### DIFF
--- a/__tests__/__utils__/test-environment.ts
+++ b/__tests__/__utils__/test-environment.ts
@@ -80,12 +80,13 @@ class LocalEnvironment extends TestEnvironment {
     const request = new Request(originalRequest, { redirect: 'manual' })
     const waitForPromises: Promise<unknown>[] = []
 
-    const response = await handleFetchEvent({
-      request,
+    const response = await handleFetchEvent(request, {
       waitUntil(promise: Promise<unknown>) {
         waitForPromises.push(promise)
       },
-    } as unknown as FetchEvent)
+      // This is needed to match the shape of the ExecutionContext type.
+      passThroughOnException() {},
+    })
 
     await Promise.all(waitForPromises)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,17 +11,18 @@ import { redirects } from './redirects'
 import { robotsTxt } from './robots'
 import { SentryFactory, Url } from './utils'
 
-if (typeof addEventListener === 'function') {
-  addEventListener('fetch', (event: Event) => {
-    const e = event as FetchEvent
-
-    e.respondWith(handleFetchEvent(e))
-  })
+// eslint-disable-next-line import/no-default-export
+export default {
+  fetch(request: Request, env: unknown, context: ExecutionContext) {
+    return handleFetchEvent(request, context)
+  },
 }
 
-export async function handleFetchEvent(event: FetchEvent): Promise<Response> {
-  const { request } = event
-  const sentryFactory = new SentryFactory(event)
+export async function handleFetchEvent(
+  request: Request,
+  context: ExecutionContext,
+): Promise<Response> {
+  const sentryFactory = new SentryFactory(context)
 
   try {
     return (

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,10 +1,10 @@
 import { Toucan } from 'toucan-js'
 
 export class SentryFactory {
-  constructor(private event: FetchEvent) {}
+  constructor(private executionContext: ExecutionContext) {}
 
   createReporter(service: string) {
-    return new SentryReporter(this.event, service)
+    return new SentryReporter(this.executionContext, service)
   }
 }
 
@@ -14,7 +14,7 @@ export class SentryReporter {
   private toucan?: Toucan
 
   constructor(
-    private event: FetchEvent,
+    private executionContext: ExecutionContext,
     private service: string,
   ) {
     this.context = {}
@@ -40,7 +40,7 @@ export class SentryReporter {
   private getToucan() {
     this.toucan ??= new Toucan({
       dsn: globalThis.SENTRY_DSN,
-      context: this.event,
+      context: this.executionContext,
       environment: globalThis.ENVIRONMENT,
       normalizeDepth: 5,
     })


### PR DESCRIPTION
Clean up of the following warning:
```
[WARNING] The entrypoint src/index.ts has exports like an ES Module, but hasn't defined a default export like a module worker normally would. Building the worker using "service-worker" format...
```

Followed the documentation in https://developers.cloudflare.com/workers/learning/migrate-to-module-workers/#migrate-a-simple-worker to use ES modules format.

--- 

Fixes #430 